### PR TITLE
Update handling for Creative Commons Licenses

### DIFF
--- a/youtube/video.py
+++ b/youtube/video.py
@@ -219,7 +219,7 @@ class VideoInfoExtractor(object):
         return re.search(r'"genre" content="(.*)"', self.html).group(1)
 
     def license(self):
-        return re.search(r'Standard YouTube License|Creative Commons - Attribution',
+        return re.search(r'Standard YouTube License|Creative Commons Attribution',
                          self.html).group()
 
     def keywords(self):


### PR DESCRIPTION
Although referenced in the documentation as "Creative Commons - Attribution", videos that actually have this license applied will be missing the hyphen. This PR fixes the issue by removing the hyphen from the text that is being searched for.

Steps to reproduce in REPL:

```python
import youtube
youtube.Video('https://www.youtube.com/watch?v=axE-AUIrtLs').license
```

In the current code, this call will fail with `AttributeError: 'NoneType' object has no attribute 'group'`.